### PR TITLE
Animate collapsible sections (open/close)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ sudo rm /usr/bin/brplot
     * ~~For that we need multithreaded queue implmenetation~~
       * !Not true, did it without it..
 * ~~Remove dependency on assert.h~~
-* Make collapasables animated.
+* ~~Make collapasables animated.~~
 * Fork a process child continues, parent execvc it's self into gdb that attaches onto a child.
 * Make event history array and print it like you do with memory so that you can debug events.
 * 3d plot wasd is broken because of something to do with rebasing

--- a/include/brui.h
+++ b/include/brui.h
@@ -115,6 +115,14 @@ typedef struct brui_pop_t {
   bool hovered;
 } brui_pop_t;
 
+typedef struct brui_collapse_t {
+  bool expanded;
+  int anim_handle; // Initialize to -1 (uninitialized). Lazily created.
+} brui_collapse_t;
+
+#define BRUI_COLLAPSE_INIT { .expanded = false, .anim_handle = -1 }
+#define BRUI_COLLAPSE_INIT_OPEN { .expanded = true, .anim_handle = -1 }
+
 typedef struct brui_action_text_t {
   brsp_id_t id;
   int cursor_pos;

--- a/src/br_plotter.h
+++ b/src/br_plotter.h
@@ -47,10 +47,10 @@ typedef struct br_plotter_ui_t {
   float default_grid_line_thickenss;
   struct {
     bool show;
-    bool key_bindings;
-    bool cli_help;
-    bool c_help;
-    bool python_help;
+    brui_collapse_t key_bindings;
+    brui_collapse_t cli_help;
+    brui_collapse_t c_help;
+    brui_collapse_t python_help;
   } help;
   struct {
     int selected_frame;
@@ -60,14 +60,14 @@ typedef struct br_plotter_ui_t {
   bool debug;
   bool dark_theme;
   bool multisampling;
-  bool expand_file;
-  bool expand_plots;
-  bool expand_optimizations;
-  bool expand_ui_styles;
-  bool expand_ui_styles_shadows;
-  bool expand_export;
-  bool expand_data;
-  bool expand_about;
+  brui_collapse_t expand_file;
+  brui_collapse_t expand_plots;
+  brui_collapse_t expand_optimizations;
+  brui_collapse_t expand_ui_styles;
+  brui_collapse_t expand_ui_styles_shadows;
+  brui_collapse_t expand_export;
+  brui_collapse_t expand_data;
+  brui_collapse_t expand_about;
   bool show_license;
   bool show_about;
   bool show_log;

--- a/src/br_ui.h
+++ b/src/br_ui.h
@@ -36,7 +36,7 @@ bool brui_vsplit_pop(void);
 void brui_background(br_bb_t bb, br_color_t color);
 void brui_border1(br_bb_t bb);
 void brui_border2(br_bb_t bb, bool active);
-bool brui_collapsable(br_strv_t name, bool* expanded);
+bool brui_collapsable(br_strv_t name, brui_collapse_t* state);
 void brui_collapsable_end(void);
 
 void brui_push(void);

--- a/src/permastate.c
+++ b/src/permastate.c
@@ -351,6 +351,19 @@ bool brps_editor_write(br_plotter_t const* br, char const* file_name) {
 
   copy.ui = br->ui;
   copy.theme = br->uiw.theme;
+  // Clear collapse animation handles before saving — they'll be lazily recreated on load
+  copy.ui.expand_file.anim_handle = -1;
+  copy.ui.expand_plots.anim_handle = -1;
+  copy.ui.expand_optimizations.anim_handle = -1;
+  copy.ui.expand_ui_styles.anim_handle = -1;
+  copy.ui.expand_ui_styles_shadows.anim_handle = -1;
+  copy.ui.expand_export.anim_handle = -1;
+  copy.ui.expand_data.anim_handle = -1;
+  copy.ui.expand_about.anim_handle = -1;
+  copy.ui.help.key_bindings.anim_handle = -1;
+  copy.ui.help.cli_help.anim_handle = -1;
+  copy.ui.help.c_help.anim_handle = -1;
+  copy.ui.help.python_help.anim_handle = -1;
   copy.ui.menu_extent_handle = brps_resizable_save(br, &copy, copy.ui.menu_extent_handle, 0);
   copy.ui.csv_file_opened = brps_string_save(br, &copy, copy.ui.csv_file_opened);
   copy.ui.font_path_id = brps_string_save(br, &copy, copy.ui.font_path_id);
@@ -395,6 +408,19 @@ bool brps_editor_read(br_plotter_t* br, char const* file_name) {
 
   br->ui = copy.ui;
   br->uiw.theme = copy.theme;
+  // Reset collapse animation handles so they're lazily recreated
+  br->ui.expand_file.anim_handle = -1;
+  br->ui.expand_plots.anim_handle = -1;
+  br->ui.expand_optimizations.anim_handle = -1;
+  br->ui.expand_ui_styles.anim_handle = -1;
+  br->ui.expand_ui_styles_shadows.anim_handle = -1;
+  br->ui.expand_export.anim_handle = -1;
+  br->ui.expand_data.anim_handle = -1;
+  br->ui.expand_about.anim_handle = -1;
+  br->ui.help.key_bindings.anim_handle = -1;
+  br->ui.help.cli_help.anim_handle = -1;
+  br->ui.help.c_help.anim_handle = -1;
+  br->ui.help.python_help.anim_handle = -1;
   br->ui.menu_extent_handle = brps_resizable_load(br, &copy, copy.ui.menu_extent_handle, 0);
   br->ui.csv_file_opened = brps_string_load(br, &copy, copy.ui.csv_file_opened);
   br->ui.font_path_id = brps_string_load(br, &copy, copy.ui.font_path_id);

--- a/src/plotter.c
+++ b/src/plotter.c
@@ -74,6 +74,19 @@ void br_plotter_init(br_plotter_t* br) {
   br_mesh_construct(&br->uiw.shaders, &br->ui.debug, &br->uiw.theme, &br->uiw.anims);
   br_plot_construct(&br->uiw.anims);
   br->ui.default_grid_line_thickenss = 1.5f;
+  // Initialize collapse animation handles to uninitialized state
+  br->ui.expand_file.anim_handle = -1;
+  br->ui.expand_plots.anim_handle = -1;
+  br->ui.expand_optimizations.anim_handle = -1;
+  br->ui.expand_ui_styles.anim_handle = -1;
+  br->ui.expand_ui_styles_shadows.anim_handle = -1;
+  br->ui.expand_export.anim_handle = -1;
+  br->ui.expand_data.anim_handle = -1;
+  br->ui.expand_about.anim_handle = -1;
+  br->ui.help.key_bindings.anim_handle = -1;
+  br->ui.help.cli_help.anim_handle = -1;
+  br->ui.help.c_help.anim_handle = -1;
+  br->ui.help.python_help.anim_handle = -1;
 
 #if BR_HAS_HOTRELOAD
   br_hotreload_start(&br->hot_state);

--- a/src/ui.c
+++ b/src/ui.c
@@ -67,6 +67,9 @@ typedef struct {
 
   float vsplit_max_height;
 
+  int collapse_anim_handle; // -1 if not a collapsable, otherwise the anim handle
+  float collapse_header_height; // height of the header portion (not animated)
+
   bool is_active;
   bool hide_border;
   bool hide_bg;
@@ -537,6 +540,7 @@ brui_stack_el_t brui_stack_el(void) {
     new_el.start_z = new_el.z;
     new_el.hide_border = false;
     new_el.hide_bg = false;
+    new_el.collapse_anim_handle = -1;
     new_el.cur_content_height = 2 * new_el.padding.y;
     return new_el;
   } else {
@@ -545,6 +549,7 @@ brui_stack_el_t brui_stack_el(void) {
       .limit = BR_EXTENT_TOBB(viewport),
       .padding = BR_THEME.padding,
       .psum = BR_THEME.padding,
+      .collapse_anim_handle = -1,
       .is_active = true
     };
     root.limit.max = br_vec2_sub(root.limit.max, root.padding);
@@ -826,27 +831,60 @@ void brui_border2(br_bb_t bb, bool active) {
   */
 }
 
-bool brui_collapsable(br_strv_t name, bool* expanded) {
+bool brui_collapsable(br_strv_t name, brui_collapse_t* state) {
   float font_size = brui_text_size();
-  //float opt_header_height /* text + 2*1/2*padding */ = font_size + TOP.padding.y;
+  // Lazily create animation handle
+  if (state->anim_handle < 0) {
+    float init = state->expanded ? 1.f : 0.f;
+    state->anim_handle = br_animf_new(&brui_state.uiw->anims, init, init);
+  }
   brui_push();
     brui_vsplitvp(2, BRUI_SPLITR(1), BRUI_SPLITA(1.3f*font_size));
-      if (brui_button(name)) *expanded = !*expanded;
+      if (brui_button(name)) state->expanded = !state->expanded;
     brui_vsplit_pop();
-      if (*expanded) {
-        if (brui_button(BR_STRL("V"))) *expanded = false;
+      if (state->expanded) {
+        if (brui_button(BR_STRL("V"))) state->expanded = false;
       } else {
-        if (brui_button(BR_STRL("<"))) *expanded = true;
+        if (brui_button(BR_STRL("<"))) state->expanded = true;
       }
     brui_vsplit_pop();
-  if (!*expanded) {
+  // Set animation target based on expanded state
+  BRUI_ANIMFS(state->anim_handle, state->expanded ? 1.f : 0.f);
+  float anim_value = BRUI_ANIMF(state->anim_handle);
+  bool should_render = anim_value > 1e-5f;
+  if (!should_render) {
     TOP.hide_bg = true;
     brui_pop();
+  } else {
+    TOP.collapse_anim_handle = state->anim_handle;
+    TOP.collapse_header_height = TOP.cur_content_height;
+    // Clip the rendering region during animation so content doesn't overflow
+    if (anim_value < 1.f - 1e-5f) {
+      float content_start = TOP.cur_pos.y;
+      float available = TOP.limit.max_y - content_start;
+      TOP.limit.max_y = content_start + available * anim_value;
+      // Sync the text renderer limits so GPU clipping works
+      brtr_state()->limits = TOP.limit;
+      // Fade content opacity based on animation progress
+      unsigned char alpha = (unsigned char)(anim_value * 255.f);
+      brtr_state()->forground.a = alpha;
+      brtr_state()->background.a = alpha;
+    }
   }
-  return *expanded;
+  return should_render;
 }
 
 void brui_collapsable_end(void) {
+  int anim_handle = TOP.collapse_anim_handle;
+  if (anim_handle >= 0) {
+    float anim_value = BRUI_ANIMF(anim_handle);
+    if (anim_value < 1.f - 1e-5f) {
+      // Only scale the body portion, keep the header height intact
+      float header_height = TOP.collapse_header_height;
+      float body_height = TOP.cur_content_height - header_height;
+      TOP.cur_content_height = header_height + body_height * anim_value;
+    }
+  }
   brui_pop();
 }
 

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -4,7 +4,7 @@
 brui_window_t win = { 0 };
 int font_size = 20;
 float something = 1.f;
-bool settings = false;
+brui_collapse_t settings = BRUI_COLLAPSE_INIT;
 
 int main(void) {
   brui_window_init(&win);
@@ -12,7 +12,7 @@ int main(void) {
     while (brpl_event_frame_next != brui_event_next(&win).kind); // You can also handle some of the events
     brui_frame_start(&win);
       brui_text_size_set(font_size);
-      brui_checkbox(BR_STRL("Settings"), &settings);
+      brui_checkbox(BR_STRL("Settings"), &settings.expanded);
       br_shaders_draw_all(win.shaders);
       if (brui_collapsable(BR_STRL("Settings"), &settings)) {
         brui_slideri(BR_STRL("Font Size"), &font_size);


### PR DESCRIPTION
## Summary

Implements animated open/close transitions for collapsible UI sections, resolving the TODO item "Make collapsibles animated" from the README.

## Changes

- **New type `brui_collapse_t`** in `brui.h` — replaces bare `bool` with a struct holding `bool expanded` + `int anim_handle` for smooth animation state
- **Smooth height transition** — body content height is scaled by the animation value (0.0→1.0), while header height stays constant to prevent layout snaps
- **GPU clipping** — `limit.max_y` and `brtr_state()->limits` are synced during animation so content is properly clipped and doesn't overflow
- **Opacity fade** — content foreground/background alpha fades in/out with animation progress
- **Lazy initialization** — animation handles use `-1` sentinel and are created on first use, so no init boilerplate is needed at callsites
- **Permastate compatibility** — animation handles are reset to `-1` on save/load to avoid stale references

## Files changed

| File | Change |
|------|--------|
| `include/brui.h` | Add `brui_collapse_t` type and init macros |
| `src/br_ui.h` | Update `brui_collapsable()` signature |
| `src/ui.c` | Core animation logic in collapsable/collapsable_end |
| `src/br_plotter.h` | Change expand bools to `brui_collapse_t` |
| `src/plotter.c` | Initialize anim handles to -1 |
| `src/permastate.c` | Reset anim handles on save/load |
| `tests/test_ui.c` | Update to use `brui_collapse_t` |
| `README.md` | Mark TODO as done |

## Note

Old editor state files (`editor.brplot`) have an incompatible struct layout and will fail to load (non-fatal error on first run). They will be regenerated on close.